### PR TITLE
removed _4 from name of library and include directory

### DIFF
--- a/cmake/PackageConfig.cmake.in
+++ b/cmake/PackageConfig.cmake.in
@@ -1,14 +1,11 @@
 @PACKAGE_INIT@
 
-#  * @PROJECT_NAME@::@PROJECT_NAME@_4 - real32 library target
-#  * @PROJECT_NAME@::@PROJECT_NAME@_8 - real64 library target
-
 # Include targets file.  This will create IMPORTED target @PROJECT_NAME@
 include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-targets.cmake")
 
-get_target_property(@PROJECT_NAME@_BUILD_TYPES @PROJECT_NAME@::@PROJECT_NAME@_4 IMPORTED_CONFIGURATIONS)
+get_target_property(@PROJECT_NAME@_BUILD_TYPES @PROJECT_NAME@::@PROJECT_NAME@ IMPORTED_CONFIGURATIONS)
 
 check_required_components("@PROJECT_NAME@")
 
-get_target_property(location @PROJECT_NAME@::@PROJECT_NAME@_4 LOCATION)
+get_target_property(location @PROJECT_NAME@::@PROJECT_NAME@ LOCATION)
 message(STATUS "Found @PROJECT_NAME@: ${location} (found version \"@PROJECT_VERSION@\")")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,7 @@
+# This is the CMake file for the src directory of the NCEPLIBS-bacio
+# project.
+#
+# Kyle Gerheiser, Ed Hartnett
 
 add_compile_definitions(UNDERSCORE)
 if(APPLE)
@@ -26,11 +30,14 @@ if(${CMAKE_Fortran_COMPILER_ID} MATCHES "^(GNU)$" AND ${CMAKE_Fortran_COMPILER_V
   set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -w -fallow-argument-mismatch")
 endif()
 
+# This is the Fortran source code.
 set(fortran_src baciof.f90 bafrio.f90 chk_endianc.f90)
+
+# This is the C source code.
 set(c_src bacio.c byteswap.c)
 
-set(lib_name ${PROJECT_NAME}_4)
-set(module_dir ${CMAKE_CURRENT_BINARY_DIR}/include_4)
+set(lib_name ${PROJECT_NAME})
+set(module_dir ${CMAKE_CURRENT_BINARY_DIR}/include)
 
 add_library(${lib_name}_f OBJECT ${fortran_src})
 set_target_properties(${lib_name}_f PROPERTIES COMPILE_FLAGS
@@ -44,7 +51,7 @@ add_library(${lib_name} STATIC $<TARGET_OBJECTS:${lib_name}_f>
   $<TARGET_OBJECTS:${lib_name}_c>)
 target_include_directories(${lib_name} INTERFACE
   $<BUILD_INTERFACE:${module_dir}>
-  $<INSTALL_INTERFACE:include_4>)
+  $<INSTALL_INTERFACE:include>)
 list(APPEND LIB_TARGETS ${lib_name})
 install(DIRECTORY ${module_dir} DESTINATION ${CMAKE_INSTALL_PREFIX})
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,17 +4,17 @@
 # Kyle Gerheiser, Ed Hartnett
 
 add_executable(test_bacio test_bacio.f90)
-target_link_libraries(test_bacio bacio_4)
+target_link_libraries(test_bacio bacio)
 add_test(test_bacio test_bacio)
 add_executable(test_bacio2 test_bacio2.f90)
-target_link_libraries(test_bacio2 bacio_4)
+target_link_libraries(test_bacio2 bacio)
 add_test(test_bacio2 test_bacio2)
 
 function(c_test name)
   add_executable(${name} ${name}.c)
-  add_dependencies(${name} bacio_4)
+  add_dependencies(${name} bacio)
   target_include_directories(${name} PRIVATE ${CMAKE_SOURCE_DIR}/src)
-  target_link_libraries(${name} PRIVATE bacio_4)
+  target_link_libraries(${name} PRIVATE bacio)
   add_test(NAME ${name} COMMAND ${name})
 endfunction()
 
@@ -22,7 +22,7 @@ c_test(test_bacio_c)
 c_test(test_byteswap)
 
 add_executable(test_bafrio test_bafrio.f90)
-target_link_libraries(test_bafrio bacio_4)
+target_link_libraries(test_bafrio bacio)
 add_test(test_bafrio test_bafrio)
 
 


### PR DESCRIPTION
Fixes #25 

In this PR I remove the "_4" from the library name and the include directory. This is ugly because all users will have to change their build systems when upgrading to bacio-2.5.0, but as we intend to move away from the _4/_8/_d libraries, this is an inevitable annoyance for every one of the NCEPLIBS fortran libraries. So we might as well get started...

We will test out the new bacio library in out NCEPLIBS-g2 testing, before doing a bacio-2.5.0 release...