### PR TITLE
Add CDash workflow

### DIFF
--- a/.github/workflows/cdash.yml
+++ b/.github/workflows/cdash.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
     - develop
-    - add_cdash
 
 jobs:
   cdash:

--- a/.github/workflows/cdash.yml
+++ b/.github/workflows/cdash.yml
@@ -1,0 +1,20 @@
+name: cdash
+on:
+  push:
+    branches:
+    - develop
+    - add_cdash
+
+jobs:
+  cdash:
+    runs-on: ubuntu-latest
+
+    env:
+      FC: gfortran
+      CC: gcc
+      CDASH_TOKEN: ${{ secrets.CDASH_TOKEN }}
+
+    steps:
+
+    - name: CDash
+      uses: NOAA-EMC/ci-cdash@develop

--- a/spack/package.py
+++ b/spack/package.py
@@ -45,5 +45,5 @@ class Bacio(CMakePackage):
             filter_file(".+", "2.4.1", "VERSION")
 
     def check(self):
-        with working_dir(self.builder.build_directory):
+        with working_dir(self.build_directory):
             make("test")


### PR DESCRIPTION
This PR adds a CI job that creates CDash info and pushes it to https://my.cdash.org/index.php?project=NCEPLIBS-bacio each time a commit is merged into develop.

Here is a successful run (the test workflow has to run in the fork due to permissions re: secrets): https://github.com/AlexanderRichert-NOAA/NCEPLIBS-bacio/actions/runs/14366643796/job/40281066207