### PR TITLE
CI: add cron's and workflow_dispatch's

### DIFF
--- a/.github/workflows/Intel.yml
+++ b/.github/workflows/Intel.yml
@@ -11,6 +11,10 @@ on:
   pull_request:
     branches:
     - develop
+  schedule:
+    # Run monthly
+    - cron: '0 0 1 * *'
+  workflow_dispatch:
 
 jobs:
   Intel:

--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -11,6 +11,10 @@ on:
   pull_request:
     branches:
     - develop
+  schedule:
+    # Run monthly
+    - cron: '0 0 1 * *'
+  workflow_dispatch:
 
 jobs:
   Linux:

--- a/.github/workflows/MacOS.yml
+++ b/.github/workflows/MacOS.yml
@@ -11,6 +11,10 @@ on:
   pull_request:
     branches:
     - develop
+  schedule:
+    # Run monthly
+    - cron: '0 0 1 * *'
+  workflow_dispatch:
 
 jobs:
   MacOS:

--- a/.github/workflows/MacOS.yml
+++ b/.github/workflows/MacOS.yml
@@ -20,8 +20,8 @@ jobs:
   MacOS:
     runs-on: macos-latest
     env:
-      FC: gfortran-12
-      CC: gcc-12
+      FC: gfortran-14
+      CC: gcc-14
     strategy:
       matrix:
         shared: [ON, OFF]

--- a/.github/workflows/Spack.yml
+++ b/.github/workflows/Spack.yml
@@ -14,6 +14,10 @@ on:
   pull_request:
     branches:
     - develop
+  schedule:
+    # Run monthly
+    - cron: '0 0 1 * *'
+  workflow_dispatch:
 
 jobs:
   # This job builds with Spack using every combination of variants and runs the CTest suite each time

--- a/.github/workflows/cdash.yml
+++ b/.github/workflows/cdash.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
     - develop
+  workflow_dispatch:
 
 jobs:
   cdash:

--- a/.github/workflows/developer.yml
+++ b/.github/workflows/developer.yml
@@ -12,6 +12,11 @@ on:
   pull_request:
     branches:
     - develop
+  schedule:
+    # Run biweekly:
+    - cron: '0 0 1 * *'
+    - cron: '0 0 15 * *'
+  workflow_dispatch:
 
 jobs:
   developer:


### PR DESCRIPTION
This PR updates CI workflows to run on cron's: biweekly for 'developer' workflow, monthly for the rest. It also adds workflow_dispatch triggers to enable running workflows manually.

Part of https://github.com/NOAA-EMC/NCEPLIBS/issues/237